### PR TITLE
fixed this.props in Picker.Item for IOS and Web

### DIFF
--- a/Components/Widgets/Picker.ios.js
+++ b/Components/Widgets/Picker.ios.js
@@ -102,7 +102,7 @@ PickerNB.Item = React.createClass({
 
     render: function() {
         return(
-          <Picker.Item {...this.props()}/>
+            <Picker.Item {...typeof this.props === "function" ? this.props() : this.props}/>
           );
     }
 });

--- a/Components/Widgets/Picker.js
+++ b/Components/Widgets/Picker.js
@@ -43,7 +43,7 @@ PickerNB.Item = React.createClass({
 
     render: function() {
         return(
-            <Picker.Item {...this.props()}/>
+            <Picker.Item {...typeof this.props === "function" ? this.props() : this.props}/>
         );
     }
 });


### PR DESCRIPTION
the Picker.Item was always rendering with this.props(), which threw an error for me because this.props is an object map.

I just added a ternary so that this.props or this.props() can work.