### PR TITLE
Added support for native-base-shoutem-theme to native-base-web components

### DIFF
--- a/Components/Base/NativeBaseComponent.js
+++ b/Components/Base/NativeBaseComponent.js
@@ -5,6 +5,8 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import lightTheme from '../Themes/light';
 
+const THEME_STYLE = "@@shoutem.theme/themeStyle";
+
 export default class NativeBaseComponent extends Component {
 	static contextTypes = {
 		theme: PropTypes.object,
@@ -23,23 +25,23 @@ export default class NativeBaseComponent extends Component {
 
 	getChildContext() {
 		return {
-			theme: this.props.theme ? this.props.theme : this.getTheme(),
-			foregroundColor: this.props.foregroundColor ?
-			this.props.foregroundColor : this.getTheme().textColor
+			theme: this.props.theme ? this.props.theme : this.context.theme,
+			foregroundColor: this.props.foregroundColor ? this.props.foregroundColor : this.getTheme().textColor
 		};
 	}
 
 	getContextForegroundColor() {
-		return this.context.foregroundColor
+		return this.context.foregroundColor || this.getTheme().textColor
 	}
 
 	getTheme() {
 		let theme = this.props.theme ? this.props.theme :
-		      this.context.theme || lightTheme;
-        if (typeof theme == 'function') {
-            return theme();
-        } else {
-            return theme;
-        }
+							this.context.theme ? this.context.theme[THEME_STYLE].variables :
+																	 lightTheme;
+		if (typeof theme == 'function') {
+				return theme();
+		} else {
+				return theme;
+		}
 	}
 }

--- a/Components/Widgets/Badge.js
+++ b/Components/Widgets/Badge.js
@@ -3,13 +3,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import Text from './Text';
 
-
-export default class BadgeNB extends NativeBaseComponent {
+class BadgeNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -58,3 +59,5 @@ export default class BadgeNB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle("NativeBase.Badge", {}, mapPropsToStyleNames)(BadgeNB);

--- a/Components/Widgets/Button.js
+++ b/Components/Widgets/Button.js
@@ -3,17 +3,18 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import { TouchableOpacity } from 'react-native';
 import Platform from '../../Utils/platform';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import computeProps from '../../Utils/computeProps';
 import IconNB from './Icon';
 import Icon from './Icon';
 import Text from './Text';
 import _ from 'lodash';
 
-
-export default class Button extends NativeBaseComponent {
+class Button extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object,
@@ -196,3 +197,9 @@ export default class Button extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.Button",
+    {},
+    mapPropsToStyleNames
+)(Button);

--- a/Components/Widgets/Card.js
+++ b/Components/Widgets/Card.js
@@ -3,11 +3,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class CardNB extends NativeBaseComponent {
+class CardNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -59,3 +61,5 @@ export default class CardNB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle("NativeBase.Card", {}, mapPropsToStyleNames)(CardNB);

--- a/Components/Widgets/CardItem.js
+++ b/Components/Widgets/CardItem.js
@@ -4,8 +4,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Image} from 'react-native';
+import { connectStyle } from 'native-base-shoutem-theme';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import Icon from './Icon';
 import Text from './Text';
 import View from './View';
@@ -13,7 +15,7 @@ import Button from './Button';
 import Thumbnail from './Thumbnail';
 import _ from 'lodash';
 
-export default class CardItemNB extends NativeBaseComponent {
+class CardItemNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object,
@@ -298,3 +300,6 @@ export default class CardItemNB extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle("NativeBase.CardItem", {}, mapPropsToStyleNames)(CardItemNB);
+

--- a/Components/Widgets/CardSwiper.js
+++ b/Components/Widgets/CardSwiper.js
@@ -3,14 +3,15 @@
 
 import React from 'react';
 import clamp from 'clamp';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {Animated, PanResponder} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import View from './View';
-
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 var SWIPE_THRESHOLD = 120;
 
-export default class CardSwiper extends NativeBaseComponent {
+class CardSwiper extends NativeBaseComponent {
 
     constructor(props) {
         super(props);
@@ -105,3 +106,10 @@ export default class CardSwiper extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.CardSwiper",
+    {},
+    mapPropsToStyleNames
+  )(CardSwiper);
+  

--- a/Components/Widgets/Checkbox.js
+++ b/Components/Widgets/Checkbox.js
@@ -3,11 +3,13 @@
 
 import React from 'react';
 import {View} from 'react-native';
+import { connectStyle } from 'native-base-shoutem-theme';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import Icon from './Icon';
 import Platform from '../../Utils/platform';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class CheckBox extends NativeBaseComponent {
+class CheckBox extends NativeBaseComponent {
 
     getInitialStyle() {
         return {
@@ -39,3 +41,9 @@ export default class CheckBox extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.CheckBox",
+    {},
+    mapPropsToStyleNames
+  )(CheckBox);

--- a/Components/Widgets/Container.js
+++ b/Components/Widgets/Container.js
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View, Image, Dimensions} from 'react-native';
 import ViewNB from './View';
 import Header from './Header';
@@ -11,8 +12,9 @@ import Footer from './Footer';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import _ from 'lodash';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class Container extends NativeBaseComponent {
+class Container extends NativeBaseComponent {
 
   propTypes: {
     style : PropTypes.object
@@ -140,3 +142,9 @@ export default class Container extends NativeBaseComponent {
   }
 
 }
+
+export default connectStyle(
+  "NativeBase.Container",
+  {},
+  mapPropsToStyleNames
+)(Container);

--- a/Components/Widgets/Content.js
+++ b/Components/Widgets/Content.js
@@ -3,11 +3,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import { ScrollView } from 'react-native';
 
-export default class Content extends NativeBaseComponent {
+class Content extends NativeBaseComponent {
 
 	propTypes: {
         padder : PropTypes.bool,
@@ -36,3 +38,9 @@ export default class Content extends NativeBaseComponent {
 		);
 	}
 }
+
+export default connectStyle(
+  "NativeBase.Content",
+  {},
+  mapPropsToStyleNames
+)(Content);

--- a/Components/Widgets/DeckSwiper.js
+++ b/Components/Widgets/DeckSwiper.js
@@ -3,13 +3,15 @@
 
 import React from 'react';
 import clamp from 'clamp';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {Animated, PanResponder} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import View from './View';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 var SWIPE_THRESHOLD = 70;
 
-export default class CardSwiper extends NativeBaseComponent {
+class DeckSwiper extends NativeBaseComponent {
 
     constructor(props) {
         super(props);
@@ -137,3 +139,9 @@ export default class CardSwiper extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.DeckSwiper",
+    {},
+    mapPropsToStyleNames
+  )(DeckSwiper);

--- a/Components/Widgets/Footer.js
+++ b/Components/Widgets/Footer.js
@@ -3,11 +3,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class Footer extends NativeBaseComponent {
+class Footer extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -66,3 +68,9 @@ export default class Footer extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.Footer",
+    {},
+    mapPropsToStyleNames
+  )(Footer);

--- a/Components/Widgets/H1.js
+++ b/Components/Widgets/H1.js
@@ -3,12 +3,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import Text from './Text';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-
-export default class H1NB extends NativeBaseComponent {
+class H1NB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -33,3 +34,9 @@ export default class H1NB extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.H1",
+    {},
+    mapPropsToStyleNames
+  )(H1NB);

--- a/Components/Widgets/H2.js
+++ b/Components/Widgets/H2.js
@@ -3,12 +3,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import Text from './Text';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 
-export default class H2NB extends NativeBaseComponent {
+class H2NB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -34,3 +36,9 @@ export default class H2NB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.H2",
+    {},
+    mapPropsToStyleNames
+  )(H2NB);

--- a/Components/Widgets/H3.js
+++ b/Components/Widgets/H3.js
@@ -3,12 +3,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import Text from './Text';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 
-export default class H3NB extends NativeBaseComponent {
+class H3NB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -34,3 +36,9 @@ export default class H3NB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.H3",
+    {},
+    mapPropsToStyleNames
+  )(H3NB);

--- a/Components/Widgets/Header.js
+++ b/Components/Widgets/Header.js
@@ -3,9 +3,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import Platform from '../../Utils/platform';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import Button from './Button';
 import View from './View';
 import Title from './Title';
@@ -13,7 +15,7 @@ import InputGroup from './InputGroup';
 import Subtitle from './Subtitle';
 import _ from 'lodash';
 
-export default class Header extends NativeBaseComponent {
+class Header extends NativeBaseComponent {
 
     propTypes: {
         searchBar : PropTypes.bool,
@@ -168,3 +170,9 @@ export default class Header extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.Header",
+    {},
+    mapPropsToStyleNames
+  )(Header);

--- a/Components/Widgets/Icon.js
+++ b/Components/Widgets/Icon.js
@@ -3,13 +3,15 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import TabBarItem from './TabBarItem';
 
-import variables from '../Themes/light';
+const THEME_STYLE = "@@shoutem.theme/themeStyle";
 
-export default class IconNB extends NativeBaseComponent {
+class IconNB extends NativeBaseComponent {
 
     static TabBarItem = TabBarItem;
 
@@ -62,13 +64,16 @@ export default class IconNB extends NativeBaseComponent {
     }
 
     render() {
-        if (this.props.family) {
-            this.setIconFamily(this.props.family);
-        } else {
-            this.setIconFamily(variables.iconFamily)
-        }
+        const iconFamily = this.props.family ?  this.props.family : this.getTheme().iconFamily;
+        this.setIconFamily(iconFamily);
         return(
             <this.Icon {...this.prepareRootProps()}/>
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.Icon",
+    {},
+    mapPropsToStyleNames
+  )(IconNB);

--- a/Components/Widgets/Input.js
+++ b/Components/Widgets/Input.js
@@ -2,11 +2,13 @@
 'use strict';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View, TextInput} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class Input extends NativeBaseComponent {
+class Input extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -42,3 +44,9 @@ export default class Input extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.Input",
+    {},
+    mapPropsToStyleNames
+  )(Input);

--- a/Components/Widgets/InputGroup.js
+++ b/Components/Widgets/InputGroup.js
@@ -3,15 +3,18 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import Icon from './Icon';
 import Button from './Button';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import Input from './Input';
 import _ from 'lodash';
 
-export default class InputGroup extends NativeBaseComponent {
+
+class InputGroup extends NativeBaseComponent {
 
 	propTypes: {
         borderType : PropTypes.string,
@@ -224,3 +227,9 @@ export default class InputGroup extends NativeBaseComponent {
 		);
 	}
 }
+
+export default connectStyle(
+	"NativeBase.InputGroup",
+	{},
+	mapPropsToStyleNames
+)(InputGroup);

--- a/Components/Widgets/List.js
+++ b/Components/Widgets/List.js
@@ -3,12 +3,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View, ListView} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import _ from 'lodash';
 
-export default class ListNB extends NativeBaseComponent {
+class ListNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object,
@@ -78,3 +80,9 @@ export default class ListNB extends NativeBaseComponent {
         }
     }
 }
+
+export default connectStyle(
+    "NativeBase.List",
+    {},
+    mapPropsToStyleNames
+  )(ListNB);

--- a/Components/Widgets/ListItem.js
+++ b/Components/Widgets/ListItem.js
@@ -3,10 +3,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {Image, TouchableWithoutFeedback } from 'react-native';
 import Platform from '../../Utils/platform';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import Icon from './Icon';
 import Text from './Text';
 import View from './View';
@@ -19,7 +21,8 @@ import InputGroup from './InputGroup';
 import TouchableOpacityScrollable from './TouchableOpacityScrollable';
 import _ from 'lodash';
 
-export default class ListItemNB extends NativeBaseComponent {
+
+class ListItemNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object,
@@ -538,3 +541,9 @@ export default class ListItemNB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.ListItem",
+    {},
+    mapPropsToStyleNames
+  )(ListItemNB);

--- a/Components/Widgets/Picker.ios.js
+++ b/Components/Widgets/Picker.ios.js
@@ -2,9 +2,11 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {Picker, Modal} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import View from './View';
 import Text from './Text';
 import List from './List';
@@ -16,8 +18,10 @@ import Button from './Button';
 import Header from './Header';
 import Title from './Title';
 import _ from 'lodash';
+import createReactClass from 'create-react-class';
 
-export default class PickerNB extends NativeBaseComponent {
+
+class PickerNB extends NativeBaseComponent {
 
     
     constructor(props) {
@@ -98,7 +102,7 @@ export default class PickerNB extends NativeBaseComponent {
 
 }
 
-PickerNB.Item = React.createClass({
+PickerNB.Item = createReactClass({
 
     render: function() {
         return(
@@ -106,3 +110,9 @@ PickerNB.Item = React.createClass({
           );
     }
 });
+
+export default connectStyle(
+    "NativeBase.Picker",
+    {},
+    mapPropsToStyleNames
+  )(PickerNB);

--- a/Components/Widgets/Picker.js
+++ b/Components/Widgets/Picker.js
@@ -2,11 +2,14 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {Picker} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
+import createReactClass from 'create-react-class';
 
-export default class PickerNB extends NativeBaseComponent {
+class PickerNB extends NativeBaseComponent {
     
     getInitialStyle() {
         return {
@@ -39,7 +42,7 @@ export default class PickerNB extends NativeBaseComponent {
 
 }
 
-PickerNB.Item = React.createClass({
+PickerNB.Item = createReactClass({
 
     render: function() {
         return(
@@ -47,3 +50,9 @@ PickerNB.Item = React.createClass({
         );
     }
 });
+
+export default connectStyle(
+    "NativeBase.Picker",
+    {},
+    mapPropsToStyleNames
+  )(PickerNB);

--- a/Components/Widgets/ProgressBar.android.js
+++ b/Components/Widgets/ProgressBar.android.js
@@ -3,11 +3,13 @@
 
 import React from 'react';
 import ProgressBar from 'ProgressBarAndroid';
+import { connectStyle } from 'native-base-shoutem-theme';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 
-export default class SpinnerNB extends NativeBaseComponent {
+class SpinnerNB extends NativeBaseComponent {
 
     prepareRootProps() {
 
@@ -34,3 +36,9 @@ export default class SpinnerNB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.Spinner",
+    {},
+    mapPropsToStyleNames
+  )(SpinnerNB);

--- a/Components/Widgets/ProgressBar.ios.js
+++ b/Components/Widgets/ProgressBar.ios.js
@@ -3,13 +3,13 @@
 
 import React from 'react';
 import { ProgressViewIOS} from 'react-native';
+import { connectStyle } from 'native-base-shoutem-theme';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 // import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 
-export default class ProgressBarNB extends NativeBaseComponent {
-
-
+class ProgressBarNB extends NativeBaseComponent {
 
 	render() {
 		return(
@@ -21,3 +21,9 @@ export default class ProgressBarNB extends NativeBaseComponent {
 	}
 
 }
+
+export default connectStyle(
+	"NativeBase.ProgressBar",
+	{},
+	mapPropsToStyleNames
+)(ProgressBarNB);

--- a/Components/Widgets/Radio.js
+++ b/Components/Widgets/Radio.js
@@ -2,12 +2,14 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import Icon from './Icon';
 import Platform from '../../Utils/platform';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class Radio extends NativeBaseComponent {
+class Radio extends NativeBaseComponent {
 
     getInitialStyle() {
         return {
@@ -27,3 +29,9 @@ export default class Radio extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.Radio",
+    {},
+    mapPropsToStyleNames
+  )(Radio);

--- a/Components/Widgets/Spinner.js
+++ b/Components/Widgets/Spinner.js
@@ -2,12 +2,13 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import { ActivityIndicator } from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-
-export default class SpinnerNB extends NativeBaseComponent {
+class SpinnerNB extends NativeBaseComponent {
 
     prepareRootProps() {
 
@@ -34,3 +35,9 @@ export default class SpinnerNB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.Spinner",
+    {},
+    mapPropsToStyleNames
+  )(SpinnerNB);

--- a/Components/Widgets/Subtitle.js
+++ b/Components/Widgets/Subtitle.js
@@ -2,11 +2,13 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import {Text, View } from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import Platform from '../../Utils/platform';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class Subtitle extends NativeBaseComponent {
+class Subtitle extends NativeBaseComponent {
 
 	render() {
 		return(
@@ -14,3 +16,9 @@ export default class Subtitle extends NativeBaseComponent {
 		);
 	}
 }
+
+export default connectStyle(
+	"NativeBase.Subtitle",
+	{},
+	mapPropsToStyleNames
+)(Subtitle);

--- a/Components/Widgets/Switch.js
+++ b/Components/Widgets/Switch.js
@@ -2,12 +2,14 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import {Switch} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class SwitchNB extends NativeBaseComponent {
+class SwitchNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -34,3 +36,9 @@ export default class SwitchNB extends NativeBaseComponent {
         );
     }
 }
+
+export default connectStyle(
+    "NativeBase.Switch",
+    {},
+    mapPropsToStyleNames
+  )(SwitchNB);

--- a/Components/Widgets/TabBarItem.js
+++ b/Components/Widgets/TabBarItem.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import { TabBarIOS } from 'react-native';
 import Icon from './Icon';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 class TabBarItem extends Component {
 
@@ -35,4 +37,8 @@ class TabBarItem extends Component {
 
 }
 
-export default TabBarItem;
+export default connectStyle(
+    "NativeBase.TabBarItem",
+    {},
+    mapPropsToStyleNames
+  )(TabBarItem);

--- a/Components/Widgets/Tabs.js
+++ b/Components/Widgets/Tabs.js
@@ -3,14 +3,16 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connectStyle } from 'native-base-shoutem-theme';
 import { Dimensions } from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import ScrollableTabView from './../vendor/react-native-scrollable-tab-view';
 import View from './View';
 import _ from 'lodash';
 
-export default class TabNB extends NativeBaseComponent {
+class TabNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object
@@ -67,3 +69,9 @@ export default class TabNB extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.Tab",
+    {},
+    mapPropsToStyleNames
+  )(TabNB);

--- a/Components/Widgets/Text.js
+++ b/Components/Widgets/Text.js
@@ -2,13 +2,15 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import {Text} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 
-export default class TextNB extends NativeBaseComponent {
+class TextNB extends NativeBaseComponent {
 
 	propTypes: {
         style : PropTypes.object
@@ -37,3 +39,9 @@ export default class TextNB extends NativeBaseComponent {
 	}
 
 }
+
+export default connectStyle(
+	"NativeBase.Text",
+	{},
+	mapPropsToStyleNames
+)(TextNB);

--- a/Components/Widgets/Textarea.js
+++ b/Components/Widgets/Textarea.js
@@ -2,12 +2,14 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import {View, TextInput} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-export default class Textarea extends NativeBaseComponent {
+class Textarea extends NativeBaseComponent {
 
 	propTypes: {
         style : PropTypes.object
@@ -64,3 +66,9 @@ export default class Textarea extends NativeBaseComponent {
 	}
 
 }
+
+export default connectStyle(
+	"NativeBase.Textarea",
+	{},
+	mapPropsToStyleNames
+)(Textarea);

--- a/Components/Widgets/Thumbnail.js
+++ b/Components/Widgets/Thumbnail.js
@@ -2,13 +2,16 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import {Image} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import _ from 'lodash';
 
-export default class ThumbnailNB extends NativeBaseComponent {
+
+class ThumbnailNB extends NativeBaseComponent {
 
     propTypes: {
         style : PropTypes.object,
@@ -54,3 +57,9 @@ export default class ThumbnailNB extends NativeBaseComponent {
             );
     }
 }
+
+export default connectStyle(
+    "NativeBase.Thumbnail",
+    {},
+    mapPropsToStyleNames
+  )(ThumbnailNB);

--- a/Components/Widgets/Title.js
+++ b/Components/Widgets/Title.js
@@ -2,15 +2,17 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import Platform from '../../Utils/platform';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
 import Text from './Text';
 import View from './View';
 import computeProps from '../../Utils/computeProps';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
 
-export default class Title extends NativeBaseComponent {
+class Title extends NativeBaseComponent {
 
 	propTypes: {
         style : PropTypes.object
@@ -40,3 +42,9 @@ export default class Title extends NativeBaseComponent {
 			);
 	}
 }
+
+export default connectStyle(
+	"NativeBase.Title",
+	{},
+	mapPropsToStyleNames
+)(Title);

--- a/Components/Widgets/TouchableOpacityScrollable.js
+++ b/Components/Widgets/TouchableOpacityScrollable.js
@@ -2,11 +2,13 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import { View, Animated } from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 import _ from 'lodash';
 
-export default class TouchableOpacityScrollable extends NativeBaseComponent {
+class TouchableOpacityScrollable extends NativeBaseComponent {
 
     constructor(props) {
         super(props);
@@ -86,3 +88,9 @@ export default class TouchableOpacityScrollable extends NativeBaseComponent {
     }
 
 }
+
+export default connectStyle(
+    "NativeBase.TouchableOpacityScrollable",
+    {},
+    mapPropsToStyleNames
+  )(TouchableOpacityScrollable);

--- a/Components/Widgets/View.js
+++ b/Components/Widgets/View.js
@@ -2,13 +2,14 @@
 'use strict';
 
 import React from 'react';
+import { connectStyle } from 'native-base-shoutem-theme';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {View} from 'react-native';
 import NativeBaseComponent from '../Base/NativeBaseComponent';
+import mapPropsToStyleNames from '../../Utils/mapPropsToStyleNames';
 
-
-export default class ViewNB extends NativeBaseComponent {
+class ViewNB extends NativeBaseComponent {
 	propTypes: {
         style : PropTypes.object,
         padder : PropTypes.bool
@@ -19,3 +20,9 @@ export default class ViewNB extends NativeBaseComponent {
 			);
 	}
 }
+
+export default connectStyle(
+	"NativeBase.View",
+	{},
+	mapPropsToStyleNames
+)(ViewNB);

--- a/Utils/mapPropsToStyleNames.js
+++ b/Utils/mapPropsToStyleNames.js
@@ -1,0 +1,16 @@
+import _ from "lodash";
+
+const mapPropsToStyleNames = (styleNames, props) => {
+  const keys = _.keys(props);
+  const values = _.values(props);
+
+  _.forEach(keys, (key, index) => {
+    if (values[index]) {
+      styleNames.push(key);
+    }
+  });
+
+  return styleNames;
+};
+
+export default mapPropsToStyleNames;

--- a/lib/Components/Base/NativeBaseComponent.js
+++ b/lib/Components/Base/NativeBaseComponent.js
@@ -26,6 +26,8 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var THEME_STYLE = "@@shoutem.theme/themeStyle";
+
 var NativeBaseComponent = function (_Component) {
 	_inherits(NativeBaseComponent, _Component);
 
@@ -39,19 +41,19 @@ var NativeBaseComponent = function (_Component) {
 		key: 'getChildContext',
 		value: function getChildContext() {
 			return {
-				theme: this.props.theme ? this.props.theme : this.getTheme(),
+				theme: this.props.theme ? this.props.theme : this.context.theme,
 				foregroundColor: this.props.foregroundColor ? this.props.foregroundColor : this.getTheme().textColor
 			};
 		}
 	}, {
 		key: 'getContextForegroundColor',
 		value: function getContextForegroundColor() {
-			return this.context.foregroundColor;
+			return this.context.foregroundColor || this.getTheme().textColor;
 		}
 	}, {
 		key: 'getTheme',
 		value: function getTheme() {
-			var theme = this.props.theme ? this.props.theme : this.context.theme || _light2.default;
+			var theme = this.props.theme ? this.props.theme : this.context.theme ? this.context.theme[THEME_STYLE].variables : _light2.default;
 			if (typeof theme == 'function') {
 				return theme();
 			} else {

--- a/lib/Components/Widgets/Badge.js
+++ b/lib/Components/Widgets/Badge.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _Text = require('./Text');
 
@@ -87,4 +93,4 @@ var BadgeNB = function (_NativeBaseComponent) {
     return BadgeNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = BadgeNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Badge", {}, _mapPropsToStyleNames2.default)(BadgeNB);

--- a/lib/Components/Widgets/Button.js
+++ b/lib/Components/Widgets/Button.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _platform = require('../../Utils/platform');
@@ -25,6 +27,10 @@ var _platform2 = _interopRequireDefault(_platform);
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _computeProps = require('../../Utils/computeProps');
 
@@ -211,4 +217,4 @@ var Button = function (_NativeBaseComponent) {
     return Button;
 }(_NativeBaseComponent3.default);
 
-exports.default = Button;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Button", {}, _mapPropsToStyleNames2.default)(Button);

--- a/lib/Components/Widgets/Card.js
+++ b/lib/Components/Widgets/Card.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -94,4 +100,4 @@ var CardNB = function (_NativeBaseComponent) {
     return CardNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = CardNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Card", {}, _mapPropsToStyleNames2.default)(CardNB);

--- a/lib/Components/Widgets/CardItem.js
+++ b/lib/Components/Widgets/CardItem.js
@@ -18,6 +18,8 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 
 var _reactNative = require('react-native');
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _Icon = require('./Icon');
 
@@ -341,4 +347,4 @@ var CardItemNB = function (_NativeBaseComponent) {
     return CardItemNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = CardItemNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.CardItem", {}, _mapPropsToStyleNames2.default)(CardItemNB);

--- a/lib/Components/Widgets/CardSwiper.js
+++ b/lib/Components/Widgets/CardSwiper.js
@@ -16,6 +16,8 @@ var _clamp = require('clamp');
 
 var _clamp2 = _interopRequireDefault(_clamp);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _View = require('./View');
 
 var _View2 = _interopRequireDefault(_View);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -152,4 +158,4 @@ var CardSwiper = function (_NativeBaseComponent) {
     return CardSwiper;
 }(_NativeBaseComponent3.default);
 
-exports.default = CardSwiper;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.CardSwiper", {}, _mapPropsToStyleNames2.default)(CardSwiper);

--- a/lib/Components/Widgets/Checkbox.js
+++ b/lib/Components/Widgets/Checkbox.js
@@ -12,6 +12,8 @@ var _react2 = _interopRequireDefault(_react);
 
 var _reactNative = require('react-native');
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
@@ -23,6 +25,10 @@ var _Icon2 = _interopRequireDefault(_Icon);
 var _platform = require('../../Utils/platform');
 
 var _platform2 = _interopRequireDefault(_platform);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -78,4 +84,4 @@ var CheckBox = function (_NativeBaseComponent) {
     return CheckBox;
 }(_NativeBaseComponent3.default);
 
-exports.default = CheckBox;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.CheckBox", {}, _mapPropsToStyleNames2.default)(CheckBox);

--- a/lib/Components/Widgets/Container.js
+++ b/lib/Components/Widgets/Container.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _View = require('./View');
@@ -45,6 +47,10 @@ var _lodash2 = _interopRequireDefault(_lodash);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -197,4 +203,4 @@ var Container = function (_NativeBaseComponent) {
   return Container;
 }(_NativeBaseComponent3.default);
 
-exports.default = Container;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Container", {}, _mapPropsToStyleNames2.default)(Container);

--- a/lib/Components/Widgets/Content.js
+++ b/lib/Components/Widgets/Content.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _reactNative = require('react-native');
 
@@ -74,4 +80,4 @@ var Content = function (_NativeBaseComponent) {
 	return Content;
 }(_NativeBaseComponent3.default);
 
-exports.default = Content;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Content", {}, _mapPropsToStyleNames2.default)(Content);

--- a/lib/Components/Widgets/DeckSwiper.js
+++ b/lib/Components/Widgets/DeckSwiper.js
@@ -16,6 +16,8 @@ var _clamp = require('clamp');
 
 var _clamp2 = _interopRequireDefault(_clamp);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _View = require('./View');
 
 var _View2 = _interopRequireDefault(_View);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -36,13 +42,13 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var SWIPE_THRESHOLD = 70;
 
-var CardSwiper = function (_NativeBaseComponent) {
-    _inherits(CardSwiper, _NativeBaseComponent);
+var DeckSwiper = function (_NativeBaseComponent) {
+    _inherits(DeckSwiper, _NativeBaseComponent);
 
-    function CardSwiper(props) {
-        _classCallCheck(this, CardSwiper);
+    function DeckSwiper(props) {
+        _classCallCheck(this, DeckSwiper);
 
-        var _this = _possibleConstructorReturn(this, (CardSwiper.__proto__ || Object.getPrototypeOf(CardSwiper)).call(this, props));
+        var _this = _possibleConstructorReturn(this, (DeckSwiper.__proto__ || Object.getPrototypeOf(DeckSwiper)).call(this, props));
 
         _this.state = {
             pan: new _reactNative.Animated.ValueXY(),
@@ -53,7 +59,7 @@ var CardSwiper = function (_NativeBaseComponent) {
         return _this;
     }
 
-    _createClass(CardSwiper, [{
+    _createClass(DeckSwiper, [{
         key: 'componentDidMount',
         value: function componentDidMount() {
             this._animateEntrance();
@@ -187,7 +193,7 @@ var CardSwiper = function (_NativeBaseComponent) {
         }
     }]);
 
-    return CardSwiper;
+    return DeckSwiper;
 }(_NativeBaseComponent3.default);
 
-exports.default = CardSwiper;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.DeckSwiper", {}, _mapPropsToStyleNames2.default)(DeckSwiper);

--- a/lib/Components/Widgets/Footer.js
+++ b/lib/Components/Widgets/Footer.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -102,4 +108,4 @@ var Footer = function (_NativeBaseComponent) {
     return Footer;
 }(_NativeBaseComponent3.default);
 
-exports.default = Footer;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Footer", {}, _mapPropsToStyleNames2.default)(Footer);

--- a/lib/Components/Widgets/H1.js
+++ b/lib/Components/Widgets/H1.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _Text = require('./Text');
 
 var _Text2 = _interopRequireDefault(_Text);
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -72,4 +78,4 @@ var H1NB = function (_NativeBaseComponent) {
     return H1NB;
 }(_NativeBaseComponent3.default);
 
-exports.default = H1NB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.H1", {}, _mapPropsToStyleNames2.default)(H1NB);

--- a/lib/Components/Widgets/H2.js
+++ b/lib/Components/Widgets/H2.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _Text = require('./Text');
 
 var _Text2 = _interopRequireDefault(_Text);
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -72,4 +78,4 @@ var H2NB = function (_NativeBaseComponent) {
     return H2NB;
 }(_NativeBaseComponent3.default);
 
-exports.default = H2NB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.H2", {}, _mapPropsToStyleNames2.default)(H2NB);

--- a/lib/Components/Widgets/H3.js
+++ b/lib/Components/Widgets/H3.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _Text = require('./Text');
 
 var _Text2 = _interopRequireDefault(_Text);
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -72,4 +78,4 @@ var H3NB = function (_NativeBaseComponent) {
     return H3NB;
 }(_NativeBaseComponent3.default);
 
-exports.default = H3NB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.H3", {}, _mapPropsToStyleNames2.default)(H3NB);

--- a/lib/Components/Widgets/Header.js
+++ b/lib/Components/Widgets/Header.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _platform = require('../../Utils/platform');
 
 var _platform2 = _interopRequireDefault(_platform);
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _Button = require('./Button');
 
@@ -238,4 +244,4 @@ var Header = function (_NativeBaseComponent) {
     return Header;
 }(_NativeBaseComponent3.default);
 
-exports.default = Header;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Header", {}, _mapPropsToStyleNames2.default)(Header);

--- a/lib/Components/Widgets/Icon.js
+++ b/lib/Components/Widgets/Icon.js
@@ -14,6 +14,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
@@ -22,13 +24,13 @@ var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
 
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
+
 var _TabBarItem = require('./TabBarItem');
 
 var _TabBarItem2 = _interopRequireDefault(_TabBarItem);
-
-var _light = require('../Themes/light');
-
-var _light2 = _interopRequireDefault(_light);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -37,6 +39,8 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var THEME_STYLE = "@@shoutem.theme/themeStyle";
 
 var IconNB = function (_NativeBaseComponent) {
     _inherits(IconNB, _NativeBaseComponent);
@@ -97,11 +101,8 @@ var IconNB = function (_NativeBaseComponent) {
     }, {
         key: 'render',
         value: function render() {
-            if (this.props.family) {
-                this.setIconFamily(this.props.family);
-            } else {
-                this.setIconFamily(_light2.default.iconFamily);
-            }
+            var iconFamily = this.props.family ? this.props.family : this.getTheme().iconFamily;
+            this.setIconFamily(iconFamily);
             return _react2.default.createElement(this.Icon, this.prepareRootProps());
         }
     }]);
@@ -110,4 +111,4 @@ var IconNB = function (_NativeBaseComponent) {
 }(_NativeBaseComponent3.default);
 
 IconNB.TabBarItem = _TabBarItem2.default;
-exports.default = IconNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Icon", {}, _mapPropsToStyleNames2.default)(IconNB);

--- a/lib/Components/Widgets/Input.js
+++ b/lib/Components/Widgets/Input.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -81,4 +87,4 @@ var Input = function (_NativeBaseComponent) {
     return Input;
 }(_NativeBaseComponent3.default);
 
-exports.default = Input;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Input", {}, _mapPropsToStyleNames2.default)(Input);

--- a/lib/Components/Widgets/InputGroup.js
+++ b/lib/Components/Widgets/InputGroup.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -33,6 +35,10 @@ var _Button2 = _interopRequireDefault(_Button);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _Input = require('./Input');
 
@@ -248,4 +254,4 @@ var InputGroup = function (_NativeBaseComponent) {
 	return InputGroup;
 }(_NativeBaseComponent3.default);
 
-exports.default = InputGroup;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.InputGroup", {}, _mapPropsToStyleNames2.default)(InputGroup);

--- a/lib/Components/Widgets/List.js
+++ b/lib/Components/Widgets/List.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _lodash = require('lodash');
 
@@ -112,4 +118,4 @@ var ListNB = function (_NativeBaseComponent) {
     return ListNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = ListNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.List", {}, _mapPropsToStyleNames2.default)(ListNB);

--- a/lib/Components/Widgets/ListItem.js
+++ b/lib/Components/Widgets/ListItem.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _platform = require('../../Utils/platform');
@@ -29,6 +31,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _Icon = require('./Icon');
 
@@ -611,4 +617,4 @@ var ListItemNB = function (_NativeBaseComponent) {
     return ListItemNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = ListItemNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.ListItem", {}, _mapPropsToStyleNames2.default)(ListItemNB);

--- a/lib/Components/Widgets/Picker.ios.js
+++ b/lib/Components/Widgets/Picker.ios.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -19,6 +21,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _View = require('./View');
 
@@ -63,6 +69,10 @@ var _Title2 = _interopRequireDefault(_Title);
 var _lodash = require('lodash');
 
 var _lodash2 = _interopRequireDefault(_lodash);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -199,10 +209,7 @@ var PickerNB = function (_NativeBaseComponent) {
     return PickerNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = PickerNB;
-
-
-PickerNB.Item = _react2.default.createClass({
+PickerNB.Item = (0, _createReactClass2.default)({
     displayName: 'Item',
 
 
@@ -210,3 +217,5 @@ PickerNB.Item = _react2.default.createClass({
         return _react2.default.createElement(_reactNative.Picker.Item, typeof this.props === "function" ? this.props() : this.props);
     }
 });
+
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Picker", {}, _mapPropsToStyleNames2.default)(PickerNB);

--- a/lib/Components/Widgets/Picker.js
+++ b/lib/Components/Widgets/Picker.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -19,6 +21,14 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -70,10 +80,7 @@ var PickerNB = function (_NativeBaseComponent) {
     return PickerNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = PickerNB;
-
-
-PickerNB.Item = _react2.default.createClass({
+PickerNB.Item = (0, _createReactClass2.default)({
     displayName: 'Item',
 
 
@@ -81,3 +88,5 @@ PickerNB.Item = _react2.default.createClass({
         return _react2.default.createElement(_reactNative.Picker.Item, typeof this.props === "function" ? this.props() : this.props);
     }
 });
+
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Picker", {}, _mapPropsToStyleNames2.default)(PickerNB);

--- a/lib/Components/Widgets/ProgressBar.android.js
+++ b/lib/Components/Widgets/ProgressBar.android.js
@@ -16,6 +16,8 @@ var _ProgressBarAndroid = require('ProgressBarAndroid');
 
 var _ProgressBarAndroid2 = _interopRequireDefault(_ProgressBarAndroid);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -67,4 +73,4 @@ var SpinnerNB = function (_NativeBaseComponent) {
     return SpinnerNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = SpinnerNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Spinner", {}, _mapPropsToStyleNames2.default)(SpinnerNB);

--- a/lib/Components/Widgets/ProgressBar.ios.js
+++ b/lib/Components/Widgets/ProgressBar.ios.js
@@ -12,9 +12,15 @@ var _react2 = _interopRequireDefault(_react);
 
 var _reactNative = require('react-native');
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -23,7 +29,6 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 // import computeProps from '../../Utils/computeProps';
 
 
@@ -47,4 +52,4 @@ var ProgressBarNB = function (_NativeBaseComponent) {
 	return ProgressBarNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = ProgressBarNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.ProgressBar", {}, _mapPropsToStyleNames2.default)(ProgressBarNB);

--- a/lib/Components/Widgets/Radio.js
+++ b/lib/Components/Widgets/Radio.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -23,6 +25,10 @@ var _Icon2 = _interopRequireDefault(_Icon);
 var _platform = require('../../Utils/platform');
 
 var _platform2 = _interopRequireDefault(_platform);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -62,4 +68,4 @@ var Radio = function (_NativeBaseComponent) {
     return Radio;
 }(_NativeBaseComponent3.default);
 
-exports.default = Radio;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Radio", {}, _mapPropsToStyleNames2.default)(Radio);

--- a/lib/Components/Widgets/Spinner.js
+++ b/lib/Components/Widgets/Spinner.js
@@ -12,6 +12,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -21,6 +23,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -64,4 +70,4 @@ var SpinnerNB = function (_NativeBaseComponent) {
     return SpinnerNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = SpinnerNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Spinner", {}, _mapPropsToStyleNames2.default)(SpinnerNB);

--- a/lib/Components/Widgets/Subtitle.js
+++ b/lib/Components/Widgets/Subtitle.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -19,6 +21,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _platform = require('../../Utils/platform');
 
 var _platform2 = _interopRequireDefault(_platform);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -55,4 +61,4 @@ var Subtitle = function (_NativeBaseComponent) {
 	return Subtitle;
 }(_NativeBaseComponent3.default);
 
-exports.default = Subtitle;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Subtitle", {}, _mapPropsToStyleNames2.default)(Subtitle);

--- a/lib/Components/Widgets/Switch.js
+++ b/lib/Components/Widgets/Switch.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -67,4 +73,4 @@ var SwitchNB = function (_NativeBaseComponent) {
     return SwitchNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = SwitchNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Switch", {}, _mapPropsToStyleNames2.default)(SwitchNB);

--- a/lib/Components/Widgets/TabBarItem.js
+++ b/lib/Components/Widgets/TabBarItem.js
@@ -12,6 +12,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -21,6 +23,10 @@ var _reactNative = require('react-native');
 var _Icon = require('./Icon');
 
 var _Icon2 = _interopRequireDefault(_Icon);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -68,4 +74,4 @@ TabBarItem.propTypes = {
     iconColor: _propTypes2.default.string,
     selectedIconColor: _propTypes2.default.string
 };
-exports.default = TabBarItem;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.TabBarItem", {}, _mapPropsToStyleNames2.default)(TabBarItem);

--- a/lib/Components/Widgets/Tabs.js
+++ b/lib/Components/Widgets/Tabs.js
@@ -16,6 +16,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _reactNativeScrollableTabView = require('./../vendor/react-native-scrollable-tab-view');
 
@@ -115,4 +121,4 @@ var TabNB = function (_NativeBaseComponent) {
     return TabNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = TabNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Tab", {}, _mapPropsToStyleNames2.default)(TabNB);

--- a/lib/Components/Widgets/Text.js
+++ b/lib/Components/Widgets/Text.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -72,4 +78,4 @@ var TextNB = function (_NativeBaseComponent) {
 	return TextNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = TextNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Text", {}, _mapPropsToStyleNames2.default)(TextNB);

--- a/lib/Components/Widgets/Textarea.js
+++ b/lib/Components/Widgets/Textarea.js
@@ -12,6 +12,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -25,6 +27,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -102,4 +108,4 @@ var Textarea = function (_NativeBaseComponent) {
 	return Textarea;
 }(_NativeBaseComponent3.default);
 
-exports.default = Textarea;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Textarea", {}, _mapPropsToStyleNames2.default)(Textarea);

--- a/lib/Components/Widgets/Thumbnail.js
+++ b/lib/Components/Widgets/Thumbnail.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -23,6 +25,10 @@ var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _lodash = require('lodash');
 
@@ -87,4 +93,4 @@ var ThumbnailNB = function (_NativeBaseComponent) {
     return ThumbnailNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = ThumbnailNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Thumbnail", {}, _mapPropsToStyleNames2.default)(ThumbnailNB);

--- a/lib/Components/Widgets/Title.js
+++ b/lib/Components/Widgets/Title.js
@@ -10,6 +10,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -33,6 +35,10 @@ var _View2 = _interopRequireDefault(_View);
 var _computeProps = require('../../Utils/computeProps');
 
 var _computeProps2 = _interopRequireDefault(_computeProps);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -87,4 +93,4 @@ var Title = function (_NativeBaseComponent) {
 	return Title;
 }(_NativeBaseComponent3.default);
 
-exports.default = Title;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.Title", {}, _mapPropsToStyleNames2.default)(Title);

--- a/lib/Components/Widgets/TouchableOpacityScrollable.js
+++ b/lib/Components/Widgets/TouchableOpacityScrollable.js
@@ -13,11 +13,17 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _reactNative = require('react-native');
 
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 var _lodash = require('lodash');
 
@@ -121,4 +127,4 @@ var TouchableOpacityScrollable = function (_NativeBaseComponent) {
     return TouchableOpacityScrollable;
 }(_NativeBaseComponent3.default);
 
-exports.default = TouchableOpacityScrollable;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.TouchableOpacityScrollable", {}, _mapPropsToStyleNames2.default)(TouchableOpacityScrollable);

--- a/lib/Components/Widgets/View.js
+++ b/lib/Components/Widgets/View.js
@@ -12,6 +12,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _nativeBaseShoutemTheme = require('native-base-shoutem-theme');
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -25,6 +27,10 @@ var _reactNative = require('react-native');
 var _NativeBaseComponent2 = require('../Base/NativeBaseComponent');
 
 var _NativeBaseComponent3 = _interopRequireDefault(_NativeBaseComponent2);
+
+var _mapPropsToStyleNames = require('../../Utils/mapPropsToStyleNames');
+
+var _mapPropsToStyleNames2 = _interopRequireDefault(_mapPropsToStyleNames);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -53,4 +59,4 @@ var ViewNB = function (_NativeBaseComponent) {
 	return ViewNB;
 }(_NativeBaseComponent3.default);
 
-exports.default = ViewNB;
+exports.default = (0, _nativeBaseShoutemTheme.connectStyle)("NativeBase.View", {}, _mapPropsToStyleNames2.default)(ViewNB);

--- a/lib/Utils/mapPropsToStyleNames.js
+++ b/lib/Utils/mapPropsToStyleNames.js
@@ -1,0 +1,26 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _lodash = require("lodash");
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var mapPropsToStyleNames = function mapPropsToStyleNames(styleNames, props) {
+  var keys = _lodash2.default.keys(props);
+  var values = _lodash2.default.values(props);
+
+  _lodash2.default.forEach(keys, function (key, index) {
+    if (values[index]) {
+      styleNames.push(key);
+    }
+  });
+
+  return styleNames;
+};
+
+exports.default = mapPropsToStyleNames;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "del-cli": "^0.2.1",
     "eslint": "^2.9.0",
     "eslint-plugin-react": "^5.0.1",
+    "native-base-shoutem-theme": "^0.2.3",
     "prop-types": "^15.6.0",
     "react": "^15.1.0",
     "react-native-web-extended": "0.0.6"


### PR DESCRIPTION
I have added support for native-base-shoutem-theme and recompiled the lib folder with the changes.

By comparing native-base and native-base-web, I saw that the support for native-base-shoutem-theme is missing. For instance, in file native-base/src/button.js; the following code is added to support shoutem-theme.

```
import { connectStyle } from "native-base-shoutem-theme";
...
// and at the end...
const StyledButton = connectStyle(
  "NativeBase.Button",
  {},
  mapPropsToStyleNames
)(Button);
export { StyledButton as Button };
```

The component file Components/Widgets/Button.js in 'native-base-web' is missing this connector.

I have added the missing connector in the pull request.